### PR TITLE
Changed the `hypertexnames` parameter.

### DIFF
--- a/template/thesis.cls
+++ b/template/thesis.cls
@@ -172,7 +172,7 @@
         commentstyle=\color[rgb]{0.13,0.55,0.13}\em,
         stringstyle=\color[rgb]{0.7,0,0} }
 \usepackage[pdfpagemode={UseOutlines},bookmarks=true,bookmarksopen=true,
-   bookmarksopenlevel=0,bookmarksnumbered=true,hypertexnames=false,
+   bookmarksopenlevel=0,bookmarksnumbered=true,hypertexnames=true,
    colorlinks,linkcolor={blue},citecolor={blue},urlcolor={red},
    pdfstartview={FitV},unicode,breaklinks=true]{hyperref}
 \pdfstringdefDisableCommands{


### PR DESCRIPTION
Changed the `hypertexnames` parameter to prevent glossary link clash. Fixes #5
